### PR TITLE
feat!: version bump to SATOSA v8.5.1

### DIFF
--- a/satosa/README-short.txt
+++ b/satosa/README-short.txt
@@ -1,1 +1,1 @@
-DEPRECATED; SATOSA translates between auth protocols such as SAML2, OpenID Connect, and OAuth2.
+SATOSA translates between auth protocols such as SAML2, OpenID Connect, and OAuth2.

--- a/satosa/content.md
+++ b/satosa/content.md
@@ -4,9 +4,7 @@ SATOSA is a configurable proxy for translating between different authentication 
 
 %%LOGO%%
 
-# How to use this image
-
-## To start a SATOSA instance
+## Using This Image
 
 The basic pattern for starting a `%%REPO%%` instance is:
 
@@ -21,8 +19,6 @@ docker run --name some-%%REPO%% -p 80:8080 -d %%IMAGE%%
 ```
 
 The entrypoint script outputs SAML2 metadata to the container log at start time. This metadata refers to the instance's base URL, e.g., `https://example.com`. Browsers must be able to access the instance over HTTPS.
-
-# How to extend this image
 
 ## Configuration files
 
@@ -48,13 +44,13 @@ docker run -it --name some-%%REPO%% %%IMAGE%% bash
 
 ## Environment variables
 
-The entrypoint script uses environment variables to generate the initial configuration, which sets SATOSA up as a SAML2 proxy between the free [SAMLtest.ID](https://samltest.id/) test service provider and test identity provider. All of the environment variables are optional.
+The entrypoint script uses environment variables to generate the initial configuration, which requires customization. All of the environment variables are **OPTIONAL**.
 
-The environment variables' values can be read from [Docker secrets](https://docs.docker.com/engine/swarm/secrets/). Append `_FILE` to the variable name (e.g., `STATE_ENCRYPTION_KEY_FILE`), and set it to the pathname of the corresponding secret (e.g., `/run/secrets/state_encryption_key`).
+Environment variables' values can be read from [Docker secrets](https://docs.docker.com/engine/swarm/secrets/). Append `_FILE` to the variable name (e.g., `STATE_ENCRYPTION_KEY_FILE`), and set it to the pathname of the corresponding secret (e.g., `/run/secrets/state_encryption_key`).
 
 ### `BASE_URL`
 
-SATOSA must be hosted at the root of the website. This environment variable optionally specifies the website's base URL, which defaults to `http://example.com`. If set, the base URL *must* be a method plus a hostname without any trailing slash or path components, e.g., `https://idproxy.example.com`, not `https://idproxy.example.com/` nor `https://idproxy.example.com/satosa`.
+SATOSA **MUST** be hosted at the root of the website. This environment variable specifies the website's base URL, which defaults to `http://example.com`. If set, the base URL *must* be a method plus a hostname without any trailing slash or path components, e.g., `https://idproxy.example.com`, not `https://idproxy.example.com/` nor `https://idproxy.example.com/satosa`.
 
 ### `STATE_ENCRYPTION_KEY`
 
@@ -62,12 +58,12 @@ SATOSA uses encrypted cookies to track the progress of an authentication flow. T
 
 ### `SAML2_BACKEND_DISCO_SRV`
 
-When part of a SAML2 multilateral federation, SATOSA will ask the user to choose an identity provider using a SAML discovery service. This environment variable optionally sets the discovery service URL, which defaults to [SeamlessAccess](https://seamlessaccess.org/).
+When part of a SAML trust federation, SATOSA will ask the user to choose an identity provider using a SAML discovery service. This environment variable sets the discovery service URL, which defaults to [SeamlessAccess](https://seamlessaccess.org/).
 
 ### `SAML2_BACKEND_CERT` and `SAML2_BACKEND_KEY`
 
-SATOSA's SAML2 backend acts like a service provider (relying party), requesting authentication by and attributes from the user's identity provider. It uses public key cryptography to sign authentication requests and decrypt responses. These optional environment variables hold the backend's paired public and private keys in [the PEM format](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail). If not specified, a new 2048-bit RSA key-pair will be generated using the hostname part of `BASE_URL`.
+SATOSA's default SAML back-end microservice acts like a service provider (relying party), requesting authentication by and attributes from the user-selected identity provider. The microservice uses public key cryptography to sign authentication requests and decrypt responses. These environment variables provide the requisite keying material in [the PEM format](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail). If not specified, a new 2048-bit RSA key-pair will be generated using the hostname part of `BASE_URL`.
 
 ### `SAML2_FRONTEND_CERT` and `SAML2_FRONTEND_KEY`
 
-SATOSA's SAML2 frontend acts like an identity provider (credential service provider), processing authentication requests from and returning user attributes to trusted websites. It uses public key cryptography to sign authentication responses. These optional environment variables hold the frontend's paired public and private keys, also in the PEM format. If not specified, a new 2048-bit RSA key-pair will be generated using the hostname part of `BASE_URL`.
+SATOSA's default SAML front-end microservice acts like an identity provider (credential service provider), processing authentication requests from and returning user attributes to trusted websites. It uses public key cryptography to sign authentication responses. These environment variables provide the requisite keying material, also in the PEM format. If not specified, a new 2048-bit RSA key-pair will be generated using the hostname part of `BASE_URL`.

--- a/satosa/deprecated.md
+++ b/satosa/deprecated.md
@@ -1,1 +1,0 @@
-This image is deprecated due to maintainer inactivity (last updated Dec 2023; [docker-library/official-images#15964](https://github.com/docker-library/official-images/pull/15964)).


### PR DESCRIPTION
This includes fixes for IdentityPython/satosa-docker#10 and IdentityPython/satosa-docker#12 as well as base image updates.  Please note that the new maintainer is the same person.  However, the work is now community-sponsored.

BREAKING CHANGE: This drops support for 32-bit architectures; cf. IdentityPython/satosa-docker#11.